### PR TITLE
Undo capitalization of file names

### DIFF
--- a/src/api/encode/encodeAsBinary.ts
+++ b/src/api/encode/encodeAsBinary.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer'
-import { Code } from '../../core/code/Code.ts'
-import { Binary } from '../../core/domain/Domains.ts'
+import { Code } from '../../core/code/code.ts'
+import { Binary } from '../../core/domain/domains.ts'
 import { encodeAsText } from './encodeAsText.ts'
 
 export const encodeAsBinary = (code: Code, primitive: Uint8Array): Binary =>

--- a/src/api/encode/encodeAsRaw.ts
+++ b/src/api/encode/encodeAsRaw.ts
@@ -1,6 +1,6 @@
 import { make } from '../../implementation/make/make.ts'
-import { Code } from '../../core/code/Code.ts'
-import { Raw } from '../../core/domain/Domains.ts'
+import { Code } from '../../core/code/code.ts'
+import { Raw } from '../../core/domain/domains.ts'
 
 export const encodeAsRaw = (code: Code, primitive: Uint8Array): Raw =>
   // Calls make() to ensure proper validation occurs before returning the result

--- a/src/api/encode/encodeAsText.ts
+++ b/src/api/encode/encodeAsText.ts
@@ -1,6 +1,6 @@
 import { pipe } from '../../lib/pipe.ts'
-import { Code } from '../../core/code/Code.ts'
-import { Text } from '../../core/domain/Domains.ts'
+import { Code } from '../../core/code/code.ts'
+import { Text } from '../../core/domain/domains.ts'
 
 import { swapInTextCode } from './lib/swapInTextCode.ts'
 import { padUpFront } from './lib/padUpFront.ts'

--- a/src/api/encode/lib/swapInTextCode.ts
+++ b/src/api/encode/lib/swapInTextCode.ts
@@ -1,5 +1,5 @@
 import { match } from 'ts-pattern'
-import { Code, CodeLength } from '../../../core/code/Code.ts'
+import { Code, CodeLength } from '../../../core/code/code.ts'
 
 type Swapper = (text: string) => string
 

--- a/src/api/transform/lib/decodeRaw.ts
+++ b/src/api/transform/lib/decodeRaw.ts
@@ -1,5 +1,5 @@
-import { Text } from '../../../core/domain/Domains.ts'
-import { Code } from '../../../core/code/Code.ts'
+import { Text } from '../../../core/domain/domains.ts'
+import { Code } from '../../../core/code/code.ts'
 
 // takes a transitional object and returns a new object with the same code and a new raw Buffer with padding intact
 export const decodeRaw = (transitional: {

--- a/src/api/transform/lib/readCode.ts
+++ b/src/api/transform/lib/readCode.ts
@@ -1,6 +1,6 @@
 import { match } from 'ts-pattern'
-import { Text } from '../../../core/domain/Domains.ts'
-import { Code } from '../../../core/code/Code.ts'
+import { Text } from '../../../core/domain/domains.ts'
+import { Code } from '../../../core/code/code.ts'
 
 const readOneCharCode = (text: Text): Code => text[0] as Code
 const readTwoCharCode = (text: Text): Code => text.substring(0, 2) as Code

--- a/src/api/transform/lib/removePadding.ts
+++ b/src/api/transform/lib/removePadding.ts
@@ -1,5 +1,5 @@
-import { Raw } from '../../../core/domain/Domains.ts'
-import { Code } from '../../../core/code/Code.ts'
+import { Raw } from '../../../core/domain/domains.ts'
+import { Code } from '../../../core/code/code.ts'
 
 // takes a transitional object removes any padding from 'raw' and returns a new Raw object
 export const removePadding = (transitional: {

--- a/src/api/transform/transformToBinary.test.ts
+++ b/src/api/transform/transformToBinary.test.ts
@@ -1,4 +1,5 @@
-import { Raw } from '../../core/domain/Domains.ts'
+
+import { Raw } from '../../core/domain/domains.ts'
 import { encodeAsBinary } from '../encode/encodeAsBinary.ts'
 import { encodeAsText } from '../encode/encodeAsText.ts'
 import { transformToBinary } from './transformToBinary.ts'

--- a/src/api/transform/transformToBinary.ts
+++ b/src/api/transform/transformToBinary.ts
@@ -1,4 +1,4 @@
-import { Binary, Text, Raw } from '../../core/domain/Domains.ts'
+import { Binary, Text, Raw } from '../../core/domain/domains.ts'
 import { encodeAsBinary } from '../encode/encodeAsBinary.ts'
 
 export function transformToBinary (text: Text): Binary

--- a/src/api/transform/transformToRaw.test.ts
+++ b/src/api/transform/transformToRaw.test.ts
@@ -1,4 +1,4 @@
-import { Binary, Raw, Text } from '../../core/domain/Domains.ts'
+import { Binary, Raw, Text } from '../../core/domain/domains.ts'
 import { encodeAsBinary } from '../encode/encodeAsBinary.ts'
 import { encodeAsText } from '../encode/encodeAsText.ts'
 import { transformToRaw } from './transformToRaw.ts'

--- a/src/api/transform/transformToRaw.ts
+++ b/src/api/transform/transformToRaw.ts
@@ -1,5 +1,5 @@
 import { match } from 'ts-pattern'
-import { Binary, Raw, Text } from '../../core/domain/Domains.ts'
+import { Binary, Raw, Text } from '../../core/domain/domains.ts'
 import { pipe } from '../../lib/pipe.ts'
 import { removePadding } from './lib/removePadding.ts'
 import { decodeRaw } from './lib/decodeRaw.ts'

--- a/src/api/transform/transformToText.test.ts
+++ b/src/api/transform/transformToText.test.ts
@@ -1,4 +1,4 @@
-import { Raw } from '../../core/domain/Domains.ts'
+import { Raw } from '../../core/domain/domains.ts'
 import { encodeAsBinary } from '../encode/encodeAsBinary.ts'
 import { encodeAsText } from '../encode/encodeAsText.ts'
 import { transformToText } from './transformToText.ts'

--- a/src/api/transform/transformToText.ts
+++ b/src/api/transform/transformToText.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer'
 
-import { Binary, Raw, Text } from '../../core/domain/Domains.ts'
+import { Binary, Raw, Text } from '../../core/domain/domains.ts'
 import { encodeAsText } from '../encode/encodeAsText.ts'
 
 export function transformToText (binary: Binary): Text

--- a/src/core/code/code.ts
+++ b/src/core/code/code.ts
@@ -1,4 +1,4 @@
-import { BasicFourCharacterCode, BasicOneCharacterCode, BasicTwoCharacterCode } from './Codes.ts'
+import { BasicFourCharacterCode, BasicOneCharacterCode, BasicTwoCharacterCode } from './codes.ts'
 
 export type CodeLength = 1 | 2 | 4
 

--- a/src/core/domain/domain.ts
+++ b/src/core/domain/domain.ts
@@ -1,3 +1,3 @@
-import { Text, Raw, Binary } from './Domains.ts'
+import { Text, Raw, Binary } from './domains.ts'
 
 export type Domain = Text | Binary | Raw

--- a/src/core/domain/domains.ts
+++ b/src/core/domain/domains.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer'
-import { Code } from '../code/Code.ts'
+import { Code } from '../code/code.ts'
 
 export type Text = string
 

--- a/src/core/primitive/primitives.ts
+++ b/src/core/primitive/primitives.ts
@@ -1,4 +1,4 @@
-import { Raw } from '../domain/Domains.ts'
+import { Raw } from '../domain/domains.ts'
 
 // One Character Codes
 export type Ed25519Seed = Raw & { readonly code: 'A' }

--- a/src/implementation/make/make.ts
+++ b/src/implementation/make/make.ts
@@ -1,7 +1,7 @@
 import { match } from 'ts-pattern'
 
-import { Code } from '../../core/code/Code.ts'
-import { Raw } from '../../core/domain/Domains.ts'
+import { Code } from '../../core/code/code.ts'
+import { Raw } from '../../core/domain/domains.ts'
 import { makeEcdsa256k1 } from './maker/makers/basicFour/makeEcdsa256k1.ts'
 import { makeSha3512 } from './maker/makers/basicTwo/sha3512.ts'
 import { makeBig } from './maker/makers/basicOne/makeBig.ts'

--- a/src/implementation/make/maker/maker.ts
+++ b/src/implementation/make/maker/maker.ts
@@ -1,3 +1,3 @@
-import { Raw } from '../../../core/domain/Domains.ts'
+import { Raw } from '../../../core/domain/domains.ts'
 
 export type Maker = (primitive: any) => Raw

--- a/src/implementation/make/maker/makers/basicFour/makeEcdsa256k1.test.ts
+++ b/src/implementation/make/maker/makers/basicFour/makeEcdsa256k1.test.ts
@@ -1,4 +1,4 @@
-import { Code } from '../../../../../core/code/Code.ts'
+import { Code } from '../../../../../core/code/code.ts'
 import { check } from '../../lib/check/check.ts'
 import { prefixNotWrong } from '../../lib/check/checks/prefixNotWrong.ts'
 import { lengthNotWrong } from '../../lib/check/checks/lengthNotWrong.ts'

--- a/src/implementation/make/maker/makers/basicFour/makeEcdsa256k1.ts
+++ b/src/implementation/make/maker/makers/basicFour/makeEcdsa256k1.ts
@@ -1,6 +1,6 @@
-import { Maker } from '../../Maker.ts'
+import { Maker } from '../../maker.ts'
 import { PrimitiveInvalidInput } from '../../error.ts'
-import { Ecdsa256k1 } from '../../../../../core/primitive/Primitives.ts'
+import { Ecdsa256k1 } from '../../../../../core/primitive/primitives.ts'
 import { primitiveIs33Bytes } from '../../lib/validate/validations/lengthIs.ts'
 import { Validation } from '../../lib/validate/Validation.ts'
 import { makeSureThat } from '../../lib/validate/validate.ts'

--- a/src/implementation/make/maker/makers/basicOne/makeBig.test.ts
+++ b/src/implementation/make/maker/makers/basicOne/makeBig.test.ts
@@ -1,4 +1,4 @@
-import { Code } from '../../../../../core/code/Code.ts'
+import { Code } from '../../../../../core/code/code.ts'
 import { check } from '../../lib/check/check.ts'
 import { lengthNotWrong } from '../../lib/check/checks/lengthNotWrong.ts'
 import { canMakeIt } from '../../lib/check/checks/canMakeIt.ts'

--- a/src/implementation/make/maker/makers/basicOne/makeBig.ts
+++ b/src/implementation/make/maker/makers/basicOne/makeBig.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer'
-import { Maker } from '../../Maker.ts'
-import { Big } from '../../../../../core/primitive/Primitives.ts'
+import { Maker } from '../../maker.ts'
+import { Big } from '../../../../../core/primitive/primitives.ts'
 import { makeSureThat } from '../../lib/validate/validate.ts'
 import { primitiveIsEightBytes } from '../../lib/validate/validations/lengthIs.ts'
 

--- a/src/implementation/make/maker/makers/basicOne/makeEd25519Seed.test.ts
+++ b/src/implementation/make/maker/makers/basicOne/makeEd25519Seed.test.ts
@@ -1,4 +1,4 @@
-import { Code } from '../../../../../core/code/Code.ts'
+import { Code } from '../../../../../core/code/code.ts'
 import { check } from '../../lib/check/check.ts'
 import { lengthNotWrong } from '../../lib/check/checks/lengthNotWrong.ts'
 import { canMakeIt } from '../../lib/check/checks/canMakeIt.ts'

--- a/src/implementation/make/maker/makers/basicOne/makeEd25519Seed.ts
+++ b/src/implementation/make/maker/makers/basicOne/makeEd25519Seed.ts
@@ -1,5 +1,5 @@
-import { Maker } from '../../Maker.ts'
-import { Ed25519Seed } from '../../../../../core/primitive/Primitives.ts'
+import { Maker } from '../../maker.ts'
+import { Ed25519Seed } from '../../../../../core/primitive/primitives.ts'
 import { primitiveIs32Bytes } from '../../lib/validate/validations/lengthIs.ts'
 import { makeSureThat } from '../../lib/validate/validate.ts'
 

--- a/src/implementation/make/maker/makers/basicOne/makeShort.test.ts
+++ b/src/implementation/make/maker/makers/basicOne/makeShort.test.ts
@@ -1,8 +1,9 @@
-import { Code } from '../../../../../core/code/Code.ts'
+
 import { check } from '../../lib/check/check.ts'
 import { lengthNotWrong } from '../../lib/check/checks/lengthNotWrong.ts'
 import { canMakeIt } from '../../lib/check/checks/canMakeIt.ts'
 import { makeShort } from './makeShort.ts'
+import { Code } from '../../../../../core/code/code.ts'
 
 const example = '011F' // becomes two byte Buffer
 

--- a/src/implementation/make/maker/makers/basicOne/makeShort.ts
+++ b/src/implementation/make/maker/makers/basicOne/makeShort.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer'
-import { Maker } from '../../Maker.ts'
-import { Short } from '../../../../../core/primitive/Primitives.ts'
+import { Maker } from '../../maker.ts'
+import { Short } from '../../../../../core/primitive/primitives.ts'
 import { makeSureThat } from '../../lib/validate/validate.ts'
 import { primitiveIsTwoBytes } from '../../lib/validate/validations/lengthIs.ts'
 

--- a/src/implementation/make/maker/makers/basicTwo/sha3512.test.ts
+++ b/src/implementation/make/maker/makers/basicTwo/sha3512.test.ts
@@ -1,4 +1,4 @@
-import { Code } from '../../../../../core/code/Code.ts'
+import { Code } from '../../../../../core/code/code.ts'
 import { check } from '../../lib/check/check.ts'
 import { lengthNotWrong } from '../../lib/check/checks/lengthNotWrong.ts'
 import { canMakeIt } from '../../lib/check/checks/canMakeIt.ts'

--- a/src/implementation/make/maker/makers/basicTwo/sha3512.ts
+++ b/src/implementation/make/maker/makers/basicTwo/sha3512.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer'
-import { Maker } from '../../Maker.ts'
-import { Sha3512 } from '../../../../../core/primitive/Primitives.ts'
+import { Maker } from '../../maker.ts'
+import { Sha3512 } from '../../../../../core/primitive/primitives.ts'
 import { makeSureThat } from '../../lib/validate/validate.ts'
 import { primitiveIs64Bytes } from '../../lib/validate/validations/lengthIs.ts'
 

--- a/testing/standardsTest/standards.test.ts
+++ b/testing/standardsTest/standards.test.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer'
 import { standards } from './standards.ts'
 import { encodeAsText } from '../../src/api/encode/encodeAsText.ts'
-import { Code } from '../../src/core/code/Code.ts'
+import { Code } from '../../src/core/code/code.ts'
 
 const matter = standards.matter
 


### PR DESCRIPTION
Turns out something wonky happens when filenames are capitalized. Seems related to ES modules and imports. File capitalization isn't important enough to be worth troubleshooting this. 